### PR TITLE
feat(frontend): add locale-prefixed routing with /es/* for Spanish

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "clsx": "^2.1.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-router-dom": "^7.13.2",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -922,6 +923,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "dev": true,
@@ -1333,6 +1347,44 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
+      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
+      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.12",
       "dev": true,
@@ -1372,6 +1424,12 @@
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "clsx": "^2.1.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-router-dom": "^7.13.2",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,5 @@
-'use client'
-
-import { useEffect, useState } from 'react'
-import { LanguageProvider } from './i18n/LanguageContext'
+import { Route, Routes, useLocation, useParams } from 'react-router-dom'
+import { LanguageProvider, type Language } from './i18n/LanguageContext'
 import Layout from './components/Layout'
 import MainHero from './components/MainHero'
 import Memorize from './pages/Memorize'
@@ -15,108 +13,45 @@ import Contact from './pages/Contact'
 import NotFound from './pages/NotFound'
 import SignUp from './pages/SignUp'
 
-type View = 'home' | 'memorize' | 'practice' | 'my-account' | 'about-me' | 'faq' | 'blog' | 'blog-post' | 'contact' | 'sign-up' | 'not-found'
-
-const viewPathMap: Record<View, string> = {
-  home: '/',
-  memorize: '/memorize',
-  practice: '/practice',
-  'my-account': '/my-account',
-  'about-me': '/about-me',
-  faq: '/faq',
-  blog: '/blog',
-  'blog-post': '/blog/:slug',
-  contact: '/contact',
-  'sign-up': '/sign-up',
-  'not-found': '/not-found',
+function PostPage() {
+  const { slug } = useParams<{ slug: string }>()
+  return slug ? <Post slug={slug} /> : <NotFound />
 }
 
-type RouteState = {
-  view: View
-  slug?: string
-}
-
-const parsePathname = (pathname: string): RouteState => {
-  if (pathname === '/') return { view: 'home' }
-  if (pathname === '/memorize') return { view: 'memorize' }
-  if (pathname === '/practice') return { view: 'practice' }
-  if (pathname === '/my-account') return { view: 'my-account' }
-  if (pathname === '/about-me') return { view: 'about-me' }
-  if (pathname === '/faq') return { view: 'faq' }
-  if (pathname === '/blog') return { view: 'blog' }
-  if (pathname.startsWith('/blog/')) {
-    const slug = pathname.slice(6) // Remove '/blog/' prefix
-    return { view: 'blog-post', slug }
-  }
-  if (pathname === '/contact') return { view: 'contact' }
-  if (pathname === '/sign-up') return { view: 'sign-up' }
-  return { view: 'not-found' }
-}
-
-const pathnameViewMap = Object.fromEntries(
-  Object.entries(viewPathMap).map(([view, path]) => [path, view as View]),
+const pageRoutes = (
+  <>
+    <Route index element={<MainHero />} />
+    <Route path="memorize" element={<Memorize />} />
+    <Route path="practice" element={<Practice />} />
+    <Route path="my-account" element={<MyAccount />} />
+    <Route path="about-me" element={<AboutMe />} />
+    <Route path="faq" element={<Faq />} />
+    <Route path="blog" element={<Blog />} />
+    <Route path="blog/:slug" element={<PostPage />} />
+    <Route path="contact" element={<Contact />} />
+    <Route path="sign-up" element={<SignUp />} />
+    <Route path="*" element={<NotFound />} />
+  </>
 )
 
-const getViewFromPathname = (pathname: string): View => pathnameViewMap[pathname] ?? 'not-found'
-const getPathFromView = (view: View, slug?: string): string => {
-  if (view === 'blog-post' && slug) {
-    return `/blog/${encodeURIComponent(slug)}`
-  }
-  return viewPathMap[view]
-}
-
-export default function Example() {
-  const [routeState, setRouteState] = useState<RouteState>(() => parsePathname(window.location.pathname))
-
-  useEffect(() => {
-    const handlePopState = () => {
-      setRouteState(parsePathname(window.location.pathname))
-    }
-
-    window.addEventListener('popstate', handlePopState)
-
-    return () => {
-      window.removeEventListener('popstate', handlePopState)
-    }
-  }, [])
-
-  const navigateToView = (view: View, slug?: string) => {
-    const nextPath = getPathFromView(view, slug)
-
-    if (window.location.pathname !== nextPath) {
-      window.history.pushState({}, '', nextPath)
-    }
-
-    setRouteState({ view, slug })
-  }
-
-  const navigateHome = () => navigateToView('home')
-  const navigateToMyAccount = () => navigateToView('my-account')
-  const navigateToMemorize = () => navigateToView('memorize')
-  const navigateToBlogPost = (slug: string) => navigateToView('blog-post', slug)
-
-  const navigateByPath = (path: string) => {
-    const state = parsePathname(path)
-    setRouteState(state)
-  }
-
-  const { view, slug } = routeState
+function AppShell() {
+  const location = useLocation()
+  const locale: Language = location.pathname === '/es' || location.pathname.startsWith('/es/') ? 'es' : 'en'
 
   return (
-    <LanguageProvider>
-      <Layout onNavigateHome={navigateHome} onNavigateToMyAccount={navigateToMyAccount} onNavigate={navigateByPath}>
-        {view === 'home' ? <MainHero onNavigateToMemorize={navigateToMemorize} onNavigateToMyAccount={navigateToMyAccount} /> : null}
-        {view === 'memorize' ? <Memorize /> : null}
-        {view === 'practice' ? <Practice /> : null}
-        {view === 'my-account' ? <MyAccount /> : null}
-        {view === 'about-me' ? <AboutMe /> : null}
-        {view === 'faq' ? <Faq /> : null}
-        {view === 'blog' ? <Blog onSelectPost={navigateToBlogPost} /> : null}
-        {view === 'blog-post' && slug ? <Post slug={slug} /> : null}
-        {view === 'contact' ? <Contact /> : null}
-        {view === 'sign-up' ? <SignUp onNavigateHome={navigateHome} /> : null}
-        {view === 'not-found' ? <NotFound onNavigateHome={navigateHome} onNavigateContact={() => navigateToView('contact')} /> : null}
-      </Layout>
+    <LanguageProvider urlLocale={locale}>
+      <Layout />
     </LanguageProvider>
+  )
+}
+
+export default function App() {
+  return (
+    <Routes>
+      <Route element={<AppShell />}>
+        <Route path="es">{pageRoutes}</Route>
+        <Route path="/">{pageRoutes}</Route>
+      </Route>
+    </Routes>
   )
 }

--- a/frontend/src/components/HeaderNavigation.tsx
+++ b/frontend/src/components/HeaderNavigation.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Suspense, lazy, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Dialog, DialogPanel } from '@headlessui/react'
 import { Bars3Icon, ChevronDownIcon, MoonIcon, SunIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { apiFetch } from '../api/client'
@@ -18,14 +19,9 @@ const navigation: { labelKey: TranslationKey; path: string }[] = [
   { labelKey: 'nav.contact', path: '/contact' },
 ]
 
-type HeaderNavigationProps = {
-  onNavigateHome: () => void
-  onNavigateToMyAccount: () => void
-  onNavigate: (path: string) => void
-}
-
-export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount, onNavigate }: HeaderNavigationProps) {
-  const { t } = useTranslation()
+export default function HeaderNavigation() {
+  const { t, localePath } = useTranslation()
+  const navigate = useNavigate()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [loginModalOpen, setLoginModalOpen] = useState(false)
   const [isAuthenticated, setIsAuthenticated] = useState(false)
@@ -75,12 +71,12 @@ export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount
 
   const handleNavigateHome = () => {
     setMobileMenuOpen(false)
-    onNavigateHome()
+    navigate(localePath('/'))
   }
 
   const handleNavigateToMyAccount = () => {
     setMobileMenuOpen(false)
-    onNavigateToMyAccount()
+    navigate(localePath('/my-account'))
   }
 
   const handleLogout = async () => {
@@ -99,7 +95,7 @@ export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount
 
       setIsAuthenticated(false)
       setMobileMenuOpen(false)
-      onNavigateHome()
+      navigate(localePath('/'))
     } catch {
       // Keep current session state if logout fails.
     }
@@ -130,16 +126,16 @@ export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount
         </div>
         <div className="hidden lg:flex lg:gap-x-12">
           {navigation.map((item) => (
-            <button key={item.labelKey} type="button" onClick={() => { setMobileMenuOpen(false); onNavigate(item.path) }} className="cursor-pointer text-sm/6 font-semibold text-foreground">
+            <button key={item.labelKey} type="button" onClick={() => { setMobileMenuOpen(false); navigate(localePath(item.path)) }} className="cursor-pointer text-sm/6 font-semibold text-foreground">
               {t(item.labelKey)}
             </button>
           ))}
           {isAuthenticated ? (
             <>
-              <button type="button" onClick={() => onNavigate('/memorize')} className="cursor-pointer text-sm/6 font-semibold text-foreground">
+              <button type="button" onClick={() => navigate(localePath('/memorize'))} className="cursor-pointer text-sm/6 font-semibold text-foreground">
                 {t('nav.memorize')}
               </button>
-              <button type="button" onClick={() => onNavigate('/practice')} className="cursor-pointer text-sm/6 font-semibold text-foreground">
+              <button type="button" onClick={() => navigate(localePath('/practice'))} className="cursor-pointer text-sm/6 font-semibold text-foreground">
                 {t('nav.practice')}
               </button>
             </>
@@ -198,7 +194,7 @@ export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount
                   <button
                     key={item.labelKey}
                     type="button"
-                    onClick={() => { setMobileMenuOpen(false); onNavigate(item.path) }}
+                    onClick={() => { setMobileMenuOpen(false); navigate(localePath(item.path)) }}
                     className="-mx-3 block rounded-full px-3 py-2 text-base/7 font-semibold text-foreground hover:bg-accent"
                   >
                     {t(item.labelKey)}
@@ -208,14 +204,14 @@ export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount
                   <>
                     <button
                       type="button"
-                      onClick={() => { setMobileMenuOpen(false); onNavigate('/memorize') }}
+                      onClick={() => { setMobileMenuOpen(false); navigate(localePath('/memorize')) }}
                       className="-mx-3 block rounded-full px-3 py-2 text-base/7 font-semibold text-foreground hover:bg-accent"
                     >
                       {t('nav.memorize')}
                     </button>
                     <button
                       type="button"
-                      onClick={() => { setMobileMenuOpen(false); onNavigate('/practice') }}
+                      onClick={() => { setMobileMenuOpen(false); navigate(localePath('/practice')) }}
                       className="-mx-3 block rounded-full px-3 py-2 text-base/7 font-semibold text-foreground hover:bg-accent"
                     >
                       {t('nav.practice')}
@@ -292,7 +288,7 @@ export default function HeaderNavigation({ onNavigateHome, onNavigateToMyAccount
             }}
             onNavigateToSignUp={() => {
               setLoginModalOpen(false)
-              onNavigate('/sign-up')
+              navigate(localePath('/sign-up'))
             }}
           />
         </Suspense>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,15 +1,8 @@
-import type { ReactNode } from 'react'
+import { Outlet } from 'react-router-dom'
 import Footer from './Footer'
 import HeaderNavigation from './HeaderNavigation'
 
-type LayoutProps = {
-  children: ReactNode
-  onNavigateHome: () => void
-  onNavigateToMyAccount: () => void
-  onNavigate: (path: string) => void
-}
-
-export default function Layout({ children, onNavigateHome, onNavigateToMyAccount, onNavigate }: LayoutProps) {
+export default function Layout() {
   return (
     <div className="relative isolate flex min-h-screen flex-col overflow-hidden bg-background">
       <div
@@ -24,8 +17,8 @@ export default function Layout({ children, onNavigateHome, onNavigateToMyAccount
           className="relative left-[calc(50%-11rem)] aspect-1155/678 w-144.5 -translate-x-1/2 rotate-30 bg-linear-to-tr from-[#ff80b5] to-[#9089fc] opacity-30 sm:left-[calc(50%-30rem)] sm:w-288.75"
         />
       </div>
-      <HeaderNavigation onNavigateHome={onNavigateHome} onNavigateToMyAccount={onNavigateToMyAccount} onNavigate={onNavigate} />
-      <main className="relative z-10 flex-1">{children}</main>
+      <HeaderNavigation />
+      <main className="relative z-10 flex-1"><Outlet /></main>
       <div
         aria-hidden="true"
         className="absolute inset-x-0 -bottom-32 -z-10 transform-gpu overflow-hidden blur-3xl sm:-bottom-56"

--- a/frontend/src/components/MainHero.tsx
+++ b/frontend/src/components/MainHero.tsx
@@ -1,13 +1,10 @@
+import { useNavigate } from 'react-router-dom'
 import Button from './Button'
 import { useTranslation } from '../i18n/LanguageContext'
 
-type MainHeroProps = {
-  onNavigateToMemorize: () => void
-  onNavigateToMyAccount: () => void
-}
-
-export default function MainHero({ onNavigateToMemorize, onNavigateToMyAccount }: MainHeroProps) {
-  const { t } = useTranslation()
+export default function MainHero() {
+  const { t, localePath } = useTranslation()
+  const navigate = useNavigate()
 
   return (
     <div className="px-6 pt-14 lg:px-8">
@@ -15,7 +12,7 @@ export default function MainHero({ onNavigateToMemorize, onNavigateToMyAccount }
         <div className="hidden sm:mb-8 sm:flex sm:justify-center">
           <div className="relative rounded-full px-3 py-1 text-sm/6 text-muted-foreground ring-1 ring-gray-900/10 hover:ring-gray-900/20 dark:ring-white/15 dark:hover:ring-white/30">
             {t('hero.badge')}{' '}
-            <button type="button" onClick={onNavigateToMyAccount} className="font-semibold text-indigo-600 dark:text-indigo-400">
+            <button type="button" onClick={() => navigate(localePath('/my-account'))} className="font-semibold text-indigo-600 dark:text-indigo-400">
               {t('hero.badgeLink')} <span aria-hidden="true">&rarr;</span>
             </button>
           </div>
@@ -28,10 +25,10 @@ export default function MainHero({ onNavigateToMemorize, onNavigateToMyAccount }
             {t('hero.description')}
           </p>
           <div className="rounded mt-10 flex items-center justify-center gap-x-6">
-            <Button type="button" onClick={onNavigateToMemorize} className="px-3.5 py-2.5">
+            <Button type="button" onClick={() => navigate(localePath('/memorize'))} className="px-3.5 py-2.5">
               {t('hero.cta')}
             </Button>
-            <Button type="button" variant="ghost" onClick={onNavigateToMyAccount} className="text-foreground">
+            <Button type="button" variant="ghost" onClick={() => navigate(localePath('/my-account'))} className="text-foreground">
               {t('hero.ctaSecondary')} <span aria-hidden="true">→</span>
             </Button>
           </div>

--- a/frontend/src/i18n/LanguageContext.tsx
+++ b/frontend/src/i18n/LanguageContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+import { createContext, useContext, useEffect, type ReactNode } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import en from './translations/en'
 import es from './translations/es'
 import type { TranslationKey } from './translations/en'
@@ -9,41 +10,52 @@ const translations: Record<Language, Record<TranslationKey, string>> = { en, es 
 
 const STORAGE_KEY = 'language'
 
-function detectLanguage(): Language {
-  try {
-    const stored = window.localStorage.getItem(STORAGE_KEY)
-    if (stored === 'en' || stored === 'es') return stored
-  } catch {
-    // localStorage unavailable
-  }
-
-  const browserLang = navigator.language.slice(0, 2)
-  return browserLang === 'es' ? 'es' : 'en'
-}
-
 type LanguageContextValue = {
   language: Language
   setLanguage: (lang: Language) => void
   t: (key: TranslationKey, params?: Record<string, string | number>) => string
+  localePath: (path: string) => string
 }
 
 const LanguageContext = createContext<LanguageContextValue | null>(null)
 
-export function LanguageProvider({ children }: { children: ReactNode }) {
-  const [language, setLanguageState] = useState<Language>(detectLanguage)
+export function LanguageProvider({ children, urlLocale }: { children: ReactNode; urlLocale: Language }) {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const language = urlLocale
 
   const setLanguage = (lang: Language) => {
-    setLanguageState(lang)
+    // Get current path without locale prefix
+    let barePath = location.pathname
+    if (barePath.startsWith('/es/')) {
+      barePath = barePath.slice(3)
+    } else if (barePath === '/es') {
+      barePath = '/'
+    }
+
+    const newPath = lang === 'en' ? barePath : (barePath === '/' ? '/es' : `/es${barePath}`)
     try {
       window.localStorage.setItem(STORAGE_KEY, lang)
     } catch {
       // localStorage unavailable
     }
+    navigate(newPath)
   }
 
   useEffect(() => {
     document.documentElement.lang = language
+    try {
+      window.localStorage.setItem(STORAGE_KEY, language)
+    } catch {
+      // localStorage unavailable
+    }
   }, [language])
+
+  const localePath = (path: string): string => {
+    if (language === 'en') return path
+    return path === '/' ? '/es' : `/es${path}`
+  }
 
   const t = (key: TranslationKey, params?: Record<string, string | number>): string => {
     let value = translations[language][key] ?? translations.en[key] ?? key
@@ -56,7 +68,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+    <LanguageContext.Provider value={{ language, setLanguage, t, localePath }}>
       {children}
     </LanguageContext.Provider>
   )

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/Blog.tsx
+++ b/frontend/src/pages/Blog.tsx
@@ -1,13 +1,10 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { fetchPosts, type PostSummary } from '../api/client'
 import CategoryBadge from '../components/CategoryBadge'
 import PageHeader from '../components/PageHeader'
 import PageShell from '../components/PageShell'
 import { useTranslation } from '../i18n/LanguageContext'
-
-interface BlogProps {
-  onSelectPost: (slug: string) => void
-}
 
 const CATEGORY_COLORS: Record<string, 'gray' | 'blue' | 'indigo' | 'green' | 'purple'> = {
   'Getting Started': 'blue',
@@ -23,8 +20,9 @@ function formatDate(dateString: string): string {
   })
 }
 
-export default function Blog({ onSelectPost }: BlogProps) {
-  const { t } = useTranslation()
+export default function Blog() {
+  const { t, localePath } = useTranslation()
+  const navigate = useNavigate()
   const [posts, setPosts] = useState<PostSummary[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -89,12 +87,12 @@ export default function Blog({ onSelectPost }: BlogProps) {
           <article
             key={post.id}
             className="group flex cursor-pointer flex-col items-start transition-all hover:opacity-75"
-            onClick={() => onSelectPost(post.slug)}
+            onClick={() => navigate(localePath(`/blog/${post.slug}`))}
             role="button"
             tabIndex={0}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
-                onSelectPost(post.slug)
+                navigate(localePath(`/blog/${post.slug}`))
               }
             }}
           >

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,14 +1,11 @@
+import { useNavigate } from 'react-router-dom'
 import Button from '../components/Button'
 import PageShell from '../components/PageShell'
 import { useTranslation } from '../i18n/LanguageContext'
 
-type NotFoundProps = {
-  onNavigateHome: () => void
-  onNavigateContact: () => void
-}
-
-export default function NotFound({ onNavigateHome, onNavigateContact }: NotFoundProps) {
-  const { t } = useTranslation()
+export default function NotFound() {
+  const { t, localePath } = useTranslation()
+  const navigate = useNavigate()
 
   return (
     <PageShell>
@@ -21,8 +18,8 @@ export default function NotFound({ onNavigateHome, onNavigateContact }: NotFound
           {t('notFound.description')}
         </p>
         <div className="mt-10 flex items-center justify-center gap-x-6">
-          <Button onClick={onNavigateHome}>{t('notFound.goHome')}</Button>
-          <button onClick={onNavigateContact} className="cursor-pointer text-sm font-semibold text-foreground">
+          <Button onClick={() => navigate(localePath('/'))}>{t('notFound.goHome')}</Button>
+          <button onClick={() => navigate(localePath('/contact'))} className="cursor-pointer text-sm font-semibold text-foreground">
             {t('notFound.contactSupport')} <span aria-hidden="true">&rarr;</span>
           </button>
         </div>

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { ApiError, apiFetch } from '../api/client'
 import Button from '../components/Button'
 import FormInput from '../components/FormInput'
@@ -6,12 +7,9 @@ import PageHeader from '../components/PageHeader'
 import PageShell from '../components/PageShell'
 import { useTranslation } from '../i18n/LanguageContext'
 
-type SignUpProps = {
-  onNavigateHome: () => void
-}
-
-export default function SignUp({ onNavigateHome }: SignUpProps) {
-  const { t } = useTranslation()
+export default function SignUp() {
+  const { t, localePath } = useTranslation()
+  const navigate = useNavigate()
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -47,7 +45,7 @@ export default function SignUp({ onNavigateHome }: SignUpProps) {
       <PageShell>
         <PageHeader title={t('signUp.successTitle')} description={t('signUp.successDescription')} />
         <div className="mt-10 flex justify-center">
-          <Button onClick={onNavigateHome}>{t('signUp.goHome')}</Button>
+          <Button onClick={() => navigate(localePath('/'))}>{t('signUp.goHome')}</Button>
         </div>
       </PageShell>
     )


### PR DESCRIPTION
## Summary

Adds locale-prefixed client-side routing using React Router. English pages are served at root paths (`/`, `/memorize`, `/blog`, etc.) and Spanish pages at `/es/*` (`/es`, `/es/memorize`, `/es/blog`, etc.).

## Changes

- **`react-router-dom`** added as a dependency
- **`main.tsx`** — wrapped `App` in `BrowserRouter`
- **`App.tsx`** — replaced manual pushState router with React Router `Routes`; defined shared page routes rendered under both `/` (en) and `/es` (es) prefixes
- **`LanguageContext.tsx`** — locale now derived from URL (`urlLocale` prop); added `localePath(path)` helper for generating locale-aware URLs; `setLanguage` navigates to equivalent URL with correct prefix
- **`Layout.tsx`** — simplified to use `Outlet` instead of callback props
- **`HeaderNavigation.tsx`** — uses `useNavigate` + `localePath` for all navigation
- **`MainHero.tsx`** — uses router navigation (no more callback props)
- **`NotFound.tsx`** — uses router navigation
- **`SignUp.tsx`** — uses router navigation
- **`Blog.tsx`** — uses `useNavigate` + `localePath` for post selection
- **`Post.tsx`** — slug read via `useParams` in `App.tsx` wrapper

## Checklist

- [x] English pages at root: `/`, `/memorize`, `/practice`, `/blog`, `/about-me`, `/faq`, `/contact`, `/my-account`, `/sign-up`
- [x] Spanish pages at `/es/*`: `/es`, `/es/memorize`, `/es/practice`, `/es/blog`, etc.
- [x] Blog detail: `/blog/:slug` (en) and `/es/blog/:slug` (es)
- [x] Language toggle navigates to equivalent URL with correct prefix
- [x] All nav links generate locale-aware URLs
- [x] `*` catch-all renders NotFound
- [x] Vite SPA fallback works (default `appType: 'spa'`)
- [x] TypeScript builds clean (`npx tsc --noEmit`)

Closes #20